### PR TITLE
Fixed memory leak in murmur3Raw.

### DIFF
--- a/src/Data/Dish/Murmur3.hs
+++ b/src/Data/Dish/Murmur3.hs
@@ -155,7 +155,9 @@ murmur3Raw val seed ver = do
   let strLength = strLFromCStr val'
   outPtr <- mallocArray arrSize
   doHash ver cstr strLength (fromIntegral seed) outPtr
-  peekArray arrSize outPtr
+  result <- peekArray arrSize outPtr
+  free outPtr
+  return result
   where arrSize = 4
         strFromCStr :: CStringLen -> CString
         strFromCStr = fst


### PR DESCRIPTION
Fix for what seems to be a pretty trivial memory leak.
Leak can be replicated with:

```
main = forever $ do
    _ <- murmur3' (Str "Test") 0 X86_32
    return ()
```
